### PR TITLE
43 add support for ascii only parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chisel-json"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2021"
 authors = ["Jonny Coombes <jcoombes@jcs-software.co.uk>"]
 rust-version = "1.56"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/jonnycoombes/chisel-json"
 [dependencies]
 fast-float = "0.2.0"
 lexical={version = "6.1.1", features = ["parse-floats", "parse-integers"], optional = true}
-chisel-decoders = "1.0.5"
+chisel-decoders = "1.0.6"
 
 [dev-dependencies]
 bytesize = "1.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,8 @@ criterion = {version ="0.4.0", features = ["html_reports"]}
 pprof = {version = "0.11.1", features = ["flamegraph", "criterion", "protobuf"]}
 
 [features]
-default = ["mixed_numerics", "default_utf8_encoding"]
+default = ["mixed_numerics" ]
 mixed_numerics = ["lexical"]
-default_utf8_encoding = []
 
 [[bench]]
 name = "dom_parsing"

--- a/README.md
+++ b/README.md
@@ -22,13 +22,11 @@ you'll never use*).
 
 ### Crate Feature Flags
 
-There are currently a few features defined within the crate:
+There currently defined features within the crate are as follows:
 
 | Feature | Description | Default Feature? |
 |---------|-------------|---------|
 | `mixed_numerics` | Should numbers be parsed separately as `i64` and `f64`? | `yerp` |
-| `default_utf8_encoding` | Will the default encoding be UTF-8? | `yerp` |
-
 
 
 ### Build & Test

--- a/README.tpl
+++ b/README.tpl
@@ -10,13 +10,11 @@
 
 ### Crate Feature Flags
 
-There are currently a few features defined within the crate:
+There currently defined features within the crate are as follows:
 
 | Feature | Description | Default Feature? |
 |---------|-------------|---------|
 | `mixed_numerics` | Should numbers be parsed separately as `i64` and `f64`? | `yerp` |
-| `default_utf8_encoding` | Will the default encoding be UTF-8? | `yerp` |
-
 
 
 ### Build & Test

--- a/src/decoders.rs
+++ b/src/decoders.rs
@@ -3,13 +3,14 @@
 //! bytes from an underlying source, and convert into a stream of `char`s.
 //!
 //! The [DecoderSelector] implemented within this module is used to instantiate new `char`
-//! iterators, based on different encodings. (Although at present, only UTF-8 is supported).
-use chisel_decoders::utf8::Utf8Decoder;
+//! iterators, based on different encodings. (Currently only ASCII and UTF-8 are supported).
+use chisel_decoders::{ascii::AsciiDecoder, utf8::Utf8Decoder};
 use std::io::BufRead;
 
 /// Enumeration of different supported encoding types
 pub enum Encoding {
     Utf8,
+    Ascii,
 }
 
 /// A struct that is essentially a factory for creating new instances of [char] iterators,
@@ -18,12 +19,12 @@ pub enum Encoding {
 pub struct DecoderSelector {}
 
 impl DecoderSelector {
-    /// Create and return an instance of the default byte decoder / char iterator
+    /// Create and return an instance of the default byte decoder / char iterator. (Utf-8)
     pub fn default_decoder<'a, Buffer: BufRead>(
         &'a self,
         buffer: &'a mut Buffer,
-    ) -> impl Iterator<Item = char> + 'a {
-        Utf8Decoder::new(buffer)
+    ) -> Box<dyn Iterator<Item = char> + 'a> {
+        Box::new(Utf8Decoder::new(buffer))
     }
 
     /// Create and return an instance of a given byte decoder / char iterator based on a specific
@@ -32,9 +33,10 @@ impl DecoderSelector {
         &'a self,
         buffer: &'a mut Buffer,
         encoding: Encoding,
-    ) -> impl Iterator<Item = char> + 'a {
+    ) -> Box<dyn Iterator<Item = char> + 'a> {
         match encoding {
-            Encoding::Utf8 => Utf8Decoder::new(buffer),
+            Encoding::Ascii => Box::new(AsciiDecoder::new(buffer)),
+            Encoding::Utf8 => Box::new(Utf8Decoder::new(buffer)),
         }
     }
 }

--- a/src/decoders.rs
+++ b/src/decoders.rs
@@ -8,15 +8,22 @@ use chisel_decoders::{ascii::AsciiDecoder, utf8::Utf8Decoder};
 use std::io::BufRead;
 
 /// Enumeration of different supported encoding types
+#[derive(Copy, Clone)]
 pub enum Encoding {
     Utf8,
     Ascii,
 }
 
+impl Default for Encoding {
+    fn default() -> Self {
+        Self::Utf8
+    }
+}
+
 /// A struct that is essentially a factory for creating new instances of [char] iterators,
 /// based on a specified encoding type
 #[derive(Default)]
-pub struct DecoderSelector {}
+pub(crate) struct DecoderSelector {}
 
 impl DecoderSelector {
     /// Create and return an instance of the default byte decoder / char iterator. (Utf-8)

--- a/src/dom.rs
+++ b/src/dom.rs
@@ -2,7 +2,7 @@
 //!
 //! Something
 use crate::coords::Coords;
-use crate::decoders::DecoderSelector;
+use crate::decoders::{DecoderSelector, Encoding};
 use std::borrow::Cow;
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
@@ -19,18 +19,36 @@ use crate::lexer::{Lexer, Token};
 use crate::JsonValue;
 
 /// Main JSON parser struct
-#[derive(Default)]
 pub struct Parser {
     decoders: DecoderSelector,
+    encoding: Encoding,
+}
+
+impl Default for Parser {
+    /// The default encoding is Utf-8
+    fn default() -> Self {
+        Self {
+            decoders: Default::default(),
+            encoding: Default::default(),
+        }
+    }
 }
 
 impl Parser {
+    /// Create a new instance of the parser using a specific [Encoding]
+    pub fn with_encoding(encoding: Encoding) -> Self {
+        Self {
+            decoders: Default::default(),
+            encoding,
+        }
+    }
+
     ///
     pub fn parse_file<PathLike: AsRef<Path>>(&self, path: PathLike) -> ParserResult<JsonValue> {
         match File::open(&path) {
             Ok(f) => {
                 let mut reader = BufReader::new(f);
-                let mut chars = self.decoders.default_decoder(&mut reader);
+                let mut chars = self.decoders.new_decoder(&mut reader, self.encoding);
                 self.parse(&mut chars)
             }
             Err(_) => {


### PR DESCRIPTION
Ascii support added through explicit creation funcs, use of the `Default` trait on the `Encoding` type.