### PR TITLE
63 add eq and hash implementations to match

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chisel-json"
-version = "0.1.20"
+version = "0.1.21"
 edition = "2021"
 authors = ["Jonny Coombes <jcoombes@jcs-software.co.uk>"]
 rust-version = "1.56"

--- a/src/events.rs
+++ b/src/events.rs
@@ -8,6 +8,7 @@ use std::borrow::Cow;
 use std::fmt::Display;
 
 /// Enumeration of the various different matches that can be produced during a parse
+#[derive(PartialEq)]
 pub enum Match<'a> {
     /// Start of the input Emitted prior to anything else
     StartOfInput,


### PR DESCRIPTION
Only a partial implementation sensible, given that `f64` isn't really a *soundly* hashable type