### PR TITLE
36 additional coords and span testing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chisel-json"
-version = "0.1.21"
+version = "0.1.22"
 edition = "2021"
 authors = ["Jonny Coombes <jcoombes@jcs-software.co.uk>"]
 rust-version = "1.56"

--- a/src/coords.rs
+++ b/src/coords.rs
@@ -29,6 +29,13 @@ impl Coords {
             self.column += 1;
         }
     }
+
+    /// Increment a coordinate by n.  Does not allow for crossing newline boundaries
+    #[inline]
+    pub fn inc_n(&mut self, n: usize) {
+        self.absolute += n;
+        self.column += n;
+    }
 }
 
 impl Display for Coords {

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -146,6 +146,12 @@ macro_rules! match_quote {
     };
 }
 
+macro_rules! match_newline {
+    () => {
+        '\n'
+    };
+}
+
 pub struct Lexer<'a> {
     /// An iterator producing `char` values
     chars: &'a mut dyn Iterator<Item = char>,


### PR DESCRIPTION
This PR adds a bunch of additional checks and tests around newline handling, in order to resolve "off by one" errors in reported line numbers for parsed content.

Also improves the accuracy of reported error coordinates through additional character pushback logic